### PR TITLE
feat: allow requests to be aborted

### DIFF
--- a/src/Form.imba
+++ b/src/Form.imba
@@ -214,6 +214,13 @@ export class Form
 			headers: headers
 		}
 
+		if config && config.canAbort
+			const abortController = new AbortController!
+
+			args[args.length - 1]['signal'] = abortController.signal
+
+			config.canAbort(abortController)
+
 		args[args.length - 1]['onUploadProgress'] = do(progressEvent)
 			self.#_progress.loaded = progressEvent.loaded
 			self.#_progress.total = progressEvent.total
@@ -252,6 +259,9 @@ export class Form
 			)
 			.catch(do(error)
 				self.#success = false
+
+				if globalThis.axios.isCancel(error)
+					return console.error(error.message)
 
 				if error.response
 					if error.response.status === 422

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -18,6 +18,7 @@ export type RequestHandle = {
     onSuccess?: (response: AxiosResponse) => void;
     onError?: (error: AxiosError) => void;
     onComplete?: () => void;
+    canAbort?: (abortController: AbortController) => void;
 }
 
 declare global {


### PR DESCRIPTION
pass an instance of AbortController via RequestHandle config

<!-- This is adapted from github.com/imba/imba -->

<!-- Provide a general summary of your changes in the Title above -->

## Description
Allow requests to be cancelled with the `canAbort` config handler.

<!-- Describe your changes in detail -->

<!-- Why is this change required? What problem does it solve? -->

<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Ran manual tests
<!-- Please describe in detail how you tested your changes. -->

<!-- Include details of your testing environment, tests ran to see how -->

## Types of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
